### PR TITLE
docs: Add link to Hackernoon blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Docker Transformer Inference
+This repository contains the code for the blog post "Deploying Transformers in Production: Simpler Than You Think" on Hackernoon: https://hackernoon.com/deploying-transformers-in-production-simpler-than-you-think
 
 A containerized solution for hosting transformer models using Flask, Gunicorn, and Docker with AWS SageMaker deployment support. Build once, run anywhere!
 


### PR DESCRIPTION
This commit adds a sentence to the README.md file to mention that this repository is a follow-along code repository for the blog post "Deploying Transformers in Production: Simpler Than You Think" on Hackernoon.